### PR TITLE
Run ci on different OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
       branches: [main]
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Run tests


### PR DESCRIPTION
Nowadays, it's piece of cake to run ci on different OSes just with 4 lines of code.

Let's do it.

sample run: https://github.com/ryoqun/enum-ptr/pull/2